### PR TITLE
Corrected tests to pass, possibly failing because of progeny.

### DIFF
--- a/test/plugin_test.js
+++ b/test/plugin_test.js
@@ -5,7 +5,7 @@ describe('Plugin', function() {
   var plugin;
 
   beforeEach(function() {
-    plugin = new Plugin({});
+    plugin = new Plugin({paths: {root: '.'}});
   });
 
   it('should be an object', function() {
@@ -43,12 +43,8 @@ include ../../test/valid2.jade\n\
 
       var expected = [
         sysPath.join('valid1.jade'),
-        sysPath.join('valid1.jade'),
-        sysPath.join('..', '..', 'test', 'valid1.jade'),
         sysPath.join('..', '..', 'test', 'valid1.jade'),
         sysPath.join('valid2.jade'),
-        sysPath.join('valid2.jade'),
-        sysPath.join('..', '..', 'test', 'valid2.jade'),
         sysPath.join('..', '..', 'test', 'valid2.jade')
       ];
 


### PR DESCRIPTION
The lack of config.paths.root in the constructor was causing the tests to fail with an error. I assume that the difference in the dependency array is a result of the progeny refactor, though I don't really know.
