### PR TITLE
Added support for static Jade compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ## jade-brunch
 Adds [Jade](http://jade-lang.com) support to [brunch](http://brunch.io), by 
-compiling templates into dynamic javascript modules. If you also want the 
-ability to compile into flat html files, check out the
-[jaded-brunch](https://github.com/monokrome/jaded-brunch) plugin.
+compiling templates into dynamic javascript modules.
 
 ## Usage
 Install the plugin via npm with `npm install --save jade-brunch`.
@@ -13,6 +11,20 @@ Or, do manual install:
   Pick a plugin version that corresponds to your minor (y) brunch version.
 * If you want to use git version of plugin, add
 `"jade-brunch": "git+ssh://git@github.com:brunch/jade-brunch.git"`.
+
+### Static HTML
+
+You may also compile to static HTML by setting `static` on the plugin 
+configuration:
+
+    plugins:
+      jade:
+        static: true
+
+In Brunch < 1.8.0, this will concatenate all matched HTML files,
+which probably isn't what you want. Beginning in Brunch 1.8.0, the
+filesets feature has a `separate` option, as described 
+[here](https://github.com/brunch/brunch/issues/616).
 
 ## Assumptions
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function JadeCompiler(cfg) {
   var defaultBaseDir = sysPath.join(cfg.paths.root, 'app');
   var config = cfg.plugins && cfg.plugins.jade;
   this.basedir = (config && config.basedir) || defaultBaseDir;
+  this.static = config && config.static;
   this.getDependencies = progeny({rootPath: this.basedir});
 }
 
@@ -18,13 +19,13 @@ JadeCompiler.prototype.extension = 'jade';
 JadeCompiler.prototype.compile = function(data, path, callback) {
   var compiled, error, result;
   try {
-    compiled = jade.compileClient(data, {
+    compiled = jade[this.static ? 'compile' : 'compileClient'](data, {
       compileDebug: false,
       filename: path,
       basedir: this.basedir,
       pretty: this.pretty
     });
-    return result = umd(compiled);
+    return result = this.static ? compiled() : umd(compiled);
   } catch (_error) {
     error = _error;
   } finally {

--- a/test.js
+++ b/test.js
@@ -29,6 +29,18 @@ describe('Plugin', function() {
     });
   });
 
+  it('should compile to static html when static option is true', function(done) {
+    var content = 'p Something';
+    var expected = '<p>Something</p>';
+
+    plugin.static = true;
+
+    plugin.compile(content, 'template.jade', function(error, data) {
+      expect(error).not.to.be.ok;
+      expect(data).to.equal(expected);
+      done();
+    });
+  });
 
   describe('getDependencies', function() {
     it('should output valid deps', function(done) {


### PR DESCRIPTION
When filesets' `separate` is available in Brunch, that'll remove the main reason for not supporting compilation to static HTML: concatenation of matched files. Because this is relatively simple, it seems better to include in the official jade-brunch than to point to a separate plugin.
